### PR TITLE
ci: Add path filtering and restore Elixir 1.17 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read
@@ -56,6 +58,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: ubuntu-22.04
+            elixir-version: 1.17.3
+            otp-version: 27.3.4
           - os: ubuntu-22.04
             elixir-version: 1.16.3
             otp-version: 26.2.5.12


### PR DESCRIPTION
- Add paths-ignore for markdown files in pull requests
- Restore Elixir 1.17.3 testing in Ubuntu compatibility matrix
- Optimize CI runs by skipping unnecessary builds for documentation changes