### PR TITLE
ci: Update OTP version to 28.0 for Elixir 1.18.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            elixir-version: 1.18.4
-            otp-version: 28.0
+            elixir-version: '1.18.4'
+            otp-version: '28.0'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     runs-on: ${{ matrix.os }}
@@ -64,14 +64,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            elixir-version: 1.17.3
-            otp-version: 27.3.4
+            elixir-version: '1.17.3'
+            otp-version: '27.3.4'
           - os: ubuntu-22.04
-            elixir-version: 1.16.3
-            otp-version: 26.2.5.12
+            elixir-version: '1.16.3'
+            otp-version: '26.2.5.12'
           - os: ubuntu-22.04
-            elixir-version: 1.15.8
-            otp-version: 25.3.2.12
+            elixir-version: '1.15.8'
+            otp-version: '25.3.2.12'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest
@@ -100,11 +100,11 @@ jobs:
       matrix:
         include:
           - os: windows-2022
-            elixir-version: 1.18.4
-            otp-version: 28.0
+            elixir-version: '1.18.4'
+            otp-version: '28.0'
           - os: windows-2019
-            elixir-version: 1.18.4
-            otp-version: 28.0
+            elixir-version: '1.18.4'
+            otp-version: '28.0'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             elixir-version: 1.18.4
-            otp-version: 27.3.4
+            otp-version: 28.0
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     runs-on: ${{ matrix.os }}
@@ -101,10 +101,10 @@ jobs:
         include:
           - os: windows-2022
             elixir-version: 1.18.4
-            otp-version: 27.3.4
+            otp-version: 28.0
           - os: windows-2019
             elixir-version: 1.18.4
-            otp-version: 27.3.4
+            otp-version: 28.0
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ be found at <https://hexdocs.pm/epmd_up>.
 
 ## Tested Platforms
 
-* Ubuntu 22.04 / Elixir 1.18 / OTP 27
+* Ubuntu 22.04 / Elixir 1.18 / OTP 28
 * Ubuntu 22.04 / Elixir 1.17 / OTP 27
 * Ubuntu 22.04 / Elixir 1.16 / OTP 26
 * Ubuntu 22.04 / Elixir 1.15 / OTP 25


### PR DESCRIPTION
- Update CI workflow to use OTP 28.0 instead of 27.3.4 for:
  - Ubuntu 22.04 with Elixir 1.18.4
  - Windows 2022 with Elixir 1.18.4
  - Windows 2019 with Elixir 1.18.4
- Update README.md to reflect OTP 28 for Ubuntu 22.04 with Elixir 1.18