### PR TITLE
feat: Add find_epmd_executable/0 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # EpmdUp
 
-A simple Elixir module to check if the Erlang Port Mapper Daemon (`epmd`) is running.
+A simple Elixir module to check and manage the Erlang Port Mapper Daemon (`epmd`).
 
 ## Overview
 
-EpmdUp provides functionality to verify the status of `epmd`, which is a critical component in Erlang/Elixir distributed systems. The Erlang Port Mapper Daemon is responsible for tracking which nodes are running on a host and which ports they are using for distributed communication.
+EpmdUp provides functionality to verify the status and location of `epmd`, which is a critical component in Erlang/Elixir distributed systems. The Erlang Port Mapper Daemon is responsible for tracking which nodes are running on a host and which ports they are using for distributed communication.
+
+## Features
+
+  * `active?/0`: Check if `epmd` is active and accepting connections
+  * `find_epmd_executable/0`: Find the full path of the `epmd` executable in the system
+  * Cross-platform support (Linux, macOS, Windows)
 
 ## Installation
 

--- a/lib/epmd_up.ex
+++ b/lib/epmd_up.ex
@@ -1,6 +1,6 @@
 defmodule EpmdUp do
   @moduledoc """
-  Documentation for `EpmdUp`.
+  A simple Elixir module to check and manage the Erlang Port Mapper Daemon (`epmd`).
   """
 
   require Logger
@@ -22,5 +22,15 @@ defmodule EpmdUp do
       {:ok, _} -> true
       {:error, _} -> false
     end
+  end
+
+  @doc """
+  Finds the full path of the Erlang Port Mapper Daemon (`epmd`) executable in the system.
+
+  Returns `nil` if the executable cannot be found in the system's PATH.
+  """
+  @spec find_epmd_executable() :: binary() | nil
+  def find_epmd_executable do
+    System.find_executable("epmd")
   end
 end

--- a/test/epmd_up_test.exs
+++ b/test/epmd_up_test.exs
@@ -8,4 +8,10 @@ defmodule EpmdUpTest do
       assert r == true || r == false
     end
   end
+
+  describe "find_epmd_executable" do
+    test "succeeds always" do
+      refute EpmdUp.find_epmd_executable() == nil
+    end
+  end
 end


### PR DESCRIPTION
- Add new function to find epmd executable path in system
- Update module documentation to reflect new functionality
- Add test case for find_epmd_executable/0
- Update README with new features section

This change adds the ability to locate the epmd executable in the system's PATH