### PR TITLE
feat: Add epmd activation functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ EpmdUp provides functionality to verify the status and location of `epmd`, which
 
 ## Features
 
+  * `activate/0`: Starts `epmd` if it's not already running.
   * `active?/0`: Check if `epmd` is active and accepting connections
   * `find_epmd_executable/0`: Find the full path of the `epmd` executable in the system
   * Cross-platform support (Linux, macOS, Windows)

--- a/lib/epmd_up.ex
+++ b/lib/epmd_up.ex
@@ -11,11 +11,13 @@ defmodule EpmdUp do
   @spec activate() :: :ok | {:error, term()}
   def activate() do
     case active?() do
-      true -> :ok
+      true ->
+        :ok
 
-      _ -> 
+      _ ->
         case find_epmd_executable() do
-          nil -> {:error, "Not found empd"}
+          nil ->
+            {:error, "Not found empd"}
 
           epmd_cmd ->
             spawn(fn -> launch_epmd(epmd_cmd) end)
@@ -56,7 +58,7 @@ defmodule EpmdUp do
 
   defp launch_epmd(epmd_cmd) do
     case System.cmd(epmd_cmd, [], parallelism: true) do
-      {result, 0} -> 
+      {result, 0} ->
         Logger.info("epmd: #{result}")
         :ok
 

--- a/lib/epmd_up.ex
+++ b/lib/epmd_up.ex
@@ -9,7 +9,7 @@ defmodule EpmdUp do
   Starts the Erlang Port Mapper Daemon (`epmd`) if it's not already running.
   """
   @spec activate() :: :ok | {:error, term()}
-  def activate() do
+  def activate do
     case active?() do
       true -> :ok
       _ -> start_epmd()
@@ -45,7 +45,7 @@ defmodule EpmdUp do
     System.find_executable("epmd")
   end
 
-  defp start_epmd() do
+  defp start_epmd do
     case find_epmd_executable() do
       nil ->
         {:error, "Not found empd"}

--- a/lib/epmd_up.ex
+++ b/lib/epmd_up.ex
@@ -6,6 +6,26 @@ defmodule EpmdUp do
   require Logger
 
   @doc """
+  Starts the Erlang Port Mapper Daemon (`epmd`) if it's not already running.
+  """
+  @spec activate() :: :ok | {:error, term()}
+  def activate() do
+    case active?() do
+      true -> :ok
+
+      _ -> 
+        case find_epmd_executable() do
+          nil -> {:error, "Not found empd"}
+
+          epmd_cmd ->
+            spawn(fn -> launch_epmd(epmd_cmd) end)
+            Logger.info("waiting launching epmd...")
+            wait_launching_epmd(5)
+        end
+    end
+  end
+
+  @doc """
   Checks if the Erlang Port Mapper Daemon (`epmd`) is active and accepting connections.
 
   This function attempts to establish a TCP connection to the `epmd` port (4369) on localhost.
@@ -32,5 +52,28 @@ defmodule EpmdUp do
   @spec find_epmd_executable() :: binary() | nil
   def find_epmd_executable do
     System.find_executable("epmd")
+  end
+
+  defp launch_epmd(epmd_cmd) do
+    case System.cmd(epmd_cmd, [], parallelism: true) do
+      {result, 0} -> 
+        Logger.info("epmd: #{result}")
+        :ok
+
+      {result, exit_code} ->
+        Logger.info("epmd: error_code: #{exit_code}")
+        {:error, exit_code}
+    end
+  end
+
+  defp wait_launching_epmd(0), do: {:error, "Fail to launch epmd."}
+
+  defp wait_launching_epmd(count) do
+    if active?() do
+      :ok
+    else
+      Process.sleep(1000)
+      wait_launching_epmd(count - 1)
+    end
   end
 end

--- a/test/epmd_up_test.exs
+++ b/test/epmd_up_test.exs
@@ -14,11 +14,11 @@ defmodule EpmdUpTest do
       refute EpmdUp.find_epmd_executable() == nil
     end
   end
-  
+
   describe "activate and active?" do
     test "active? after activate" do
       assert EpmdUp.activate() == :ok
-      assert EpmdUp.active?() 
+      assert EpmdUp.active?()
     end
   end
 end

--- a/test/epmd_up_test.exs
+++ b/test/epmd_up_test.exs
@@ -14,4 +14,11 @@ defmodule EpmdUpTest do
       refute EpmdUp.find_epmd_executable() == nil
     end
   end
+  
+  describe "activate and active?" do
+    test "active? after activate" do
+      assert EpmdUp.activate() == :ok
+      assert EpmdUp.active?() 
+    end
+  end
 end


### PR DESCRIPTION
- Add activate/0 function to start epmd if not running
- Implement retry mechanism with timeout for epmd startup
- Add error handling and logging for epmd activation
- Update README.md to document new activate/0 feature
- Add test cases for activate/0 functionality

This change allows users to programmatically start epmd when needed, making the library more complete for managing the Erlang Port Mapper Daemon.