### PR TITLE
feat: Add epmd deactivation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ EpmdUp provides functionality to verify the status and location of `epmd`, which
 
 ## Features
 
-  * `activate/0`: Starts `epmd` if it's not already running.
+  * `activate/0`: Starts `epmd` if it's not already running
   * `active?/0`: Check if `epmd` is active and accepting connections
+  * `deactivate/0`: Stops `epmd` if it's running
   * `find_epmd_executable/0`: Find the full path of the `epmd` executable in the system
   * Cross-platform support (Linux, macOS, Windows)
 

--- a/test/epmd_up_test.exs
+++ b/test/epmd_up_test.exs
@@ -15,8 +15,12 @@ defmodule EpmdUpTest do
     end
   end
 
-  describe "activate and active?" do
-    test "active? after activate" do
+  describe "activate, deactivate and active?" do
+    test "activate, deactivate and active?" do
+      assert EpmdUp.activate() == :ok
+      assert EpmdUp.active?()
+      assert EpmdUp.deactivate() == :ok
+      refute EpmdUp.active?()
       assert EpmdUp.activate() == :ok
       assert EpmdUp.active?()
     end


### PR DESCRIPTION
- Add deactivate/0 function to stop epmd using Kill EPMD protocol
- Implement retry mechanism with timeout for epmd termination
- Add error handling and logging for epmd deactivation
- Update README.md to document new deactivate/0 feature
- Enhance test cases to cover complete epmd lifecycle

This change allows users to programmatically stop epmd when needed, completing the library's ability to fully manage the Erlang Port Mapper Daemon.