### PR TITLE
ci: update CI matrix to support Elixir 1.19 and OTP 28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             elixir-version: '1.18.4'
-            otp-version: '27.3.4'
+            otp-version: '28.0.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     runs-on: ${{ matrix.os }}
@@ -64,14 +64,20 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
+            elixir-version: '1.19.0-rc.0'
+            otp-version: '28.0.1'
+          - os: ubuntu-22.04
+            elixir-version: '1.18.4'
+            otp-version: '27.3.4.1'
+          - os: ubuntu-22.04
             elixir-version: '1.17.3'
-            otp-version: '27.3.4'
+            otp-version: '27.3.4.1'
           - os: ubuntu-22.04
             elixir-version: '1.16.3'
-            otp-version: '26.2.5.12'
+            otp-version: '26.2.5.13'
           - os: ubuntu-22.04
             elixir-version: '1.15.8'
-            otp-version: '25.3.2.12'
+            otp-version: '25.3.2.21'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest
@@ -100,11 +106,14 @@ jobs:
       matrix:
         include:
           - os: windows-2022
+            elixir-version: '1.19.0-rc.0'
+            otp-version: '28.0.1'
+          - os: windows-2022
             elixir-version: '1.18.4'
-            otp-version: '27.3.4'
+            otp-version: '28.0.1'
           - os: windows-2019
             elixir-version: '1.18.4'
-            otp-version: '27.3.4'
+            otp-version: '28.0.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest

--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ be found at <https://hexdocs.pm/epmd_up>.
 
 ## Tested Platforms
 
+* Ubuntu 22.04 / Elixir 1.19 / OTP 28
+* Ubuntu 22.04 / Elixir 1.18 / OTP 28
 * Ubuntu 22.04 / Elixir 1.18 / OTP 27
 * Ubuntu 22.04 / Elixir 1.17 / OTP 27
 * Ubuntu 22.04 / Elixir 1.16 / OTP 26
 * Ubuntu 22.04 / Elixir 1.15 / OTP 25
-* Windows 2022 / Elixir 1.18 / OTP 27
-* Windows 2019 / Elixir 1.18 / OTP 27
+* Windows 2022 / Elixir 1.19 / OTP 28
+* Windows 2022 / Elixir 1.18 / OTP 28
+* Windows 2019 / Elixir 1.18 / OTP 28
 
 ## License
 


### PR DESCRIPTION
- Add Elixir 1.19.0-rc.0 with OTP 28.0.1 to CI matrix
- Update existing Elixir versions to latest OTP patch releases
- Update Windows platforms to use OTP 28.0.1
- Update README to reflect new supported platform versions

This ensures compatibility with the latest Elixir and OTP releases.