### PR TITLE
ci: update OTP versions in test matrix and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             elixir-version: '1.18.4'
-            otp-version: '28.0.1'
+            otp-version: '28.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     runs-on: ${{ matrix.os }}
@@ -61,19 +61,19 @@ jobs:
         include:
           - os: ubuntu-22.04
             elixir-version: '1.19.0-rc.0'
-            otp-version: '28.0.1'
+            otp-version: '28.1'
           - os: ubuntu-22.04
             elixir-version: '1.18.4'
-            otp-version: '27.3.4.1'
+            otp-version: '27.3.4.3'
           - os: ubuntu-22.04
             elixir-version: '1.17.3'
-            otp-version: '27.3.4.1'
+            otp-version: '27.3.4.4'
           - os: ubuntu-22.04
             elixir-version: '1.16.3'
-            otp-version: '26.2.5.13'
+            otp-version: '26.2.5.15'
           - os: ubuntu-22.04
             elixir-version: '1.15.8'
-            otp-version: '25.3.2.21'
+            otp-version: '26.2.5.15'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest
@@ -103,10 +103,10 @@ jobs:
         include:
           - os: windows-2022
             elixir-version: '1.19.0-rc.0'
-            otp-version: '28.0.1'
+            otp-version: '28.1'
           - os: windows-2022
             elixir-version: '1.18.4'
-            otp-version: '28.0.1'
+            otp-version: '28.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest
@@ -136,7 +136,7 @@ jobs:
         include:
           - os: macos-14-xlarge
             elixir-version: '1.18.4'
-            otp-version: '28.0.1'
+            otp-version: '28.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ be found at <https://hexdocs.pm/epmd_up>.
 * Ubuntu 22.04 / Elixir 1.18 / OTP 27
 * Ubuntu 22.04 / Elixir 1.17 / OTP 27
 * Ubuntu 22.04 / Elixir 1.16 / OTP 26
-* Ubuntu 22.04 / Elixir 1.15 / OTP 25
+* Ubuntu 22.04 / Elixir 1.15 / OTP 26
 * Windows 2022 / Elixir 1.19 / OTP 28
 * Windows 2022 / Elixir 1.18 / OTP 28
 * macOS Sonoma on Apple Silicon / Elixir 1.18 / OTP 28


### PR DESCRIPTION
- Update OTP 28.0.1 → 28.1 for latest Elixir versions
- Update OTP 27.3.4.1 → 27.3.4.3/27.3.4.4 for Elixir 1.17-1.18
- Update OTP 26.2.5.13 → 26.2.5.15 for Elixir 1.16
- Update OTP 25.3.2.21 → 26.2.5.15 for Elixir 1.15
- Update README.md to reflect OTP 26 for Elixir 1.15