### PR TITLE
ci: add Windows 2025 support to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
           - os: windows-2022
             elixir-version: '1.18.4'
             otp-version: '28.1'
+          - os: windows-2025
+            elixir-version: '1.19.0-rc.0'
+            otp-version: '28.1'
+          - os: windows-2025
+            elixir-version: '1.18.4'
+            otp-version: '28.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ be found at <https://hexdocs.pm/epmd_up>.
 * Ubuntu 22.04 / Elixir 1.17 / OTP 27
 * Ubuntu 22.04 / Elixir 1.16 / OTP 26
 * Ubuntu 22.04 / Elixir 1.15 / OTP 26
+* Windows 2025 / Elixir 1.19 / OTP 28
 * Windows 2022 / Elixir 1.19 / OTP 28
+* Windows 2025 / Elixir 1.18 / OTP 28
 * Windows 2022 / Elixir 1.18 / OTP 28
 * macOS Sonoma on Apple Silicon / Elixir 1.18 / OTP 28
 


### PR DESCRIPTION
- Add Windows 2025 test configurations for Elixir 1.19 and 1.18
- Update README.md to document Windows 2025 platform support
- Both configurations use OTP 28.1